### PR TITLE
Added functionality to add in additional .png, .jpeg, .preview.png, .preview.jpg, and .preview.jpeg file types

### DIFF
--- a/components/utility.py
+++ b/components/utility.py
@@ -23,7 +23,7 @@ import nodes
 from ..utils import comfy_dir
 import collections
 
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".webp"]
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".webp", ".preview.png", ".preview.jpg", ".preview.jpeg",]
 STANDARD_SIDES = np.arange(64, 2049, 16).tolist()
 CASCADE_SIDES = np.arange(64, 2049, 16).tolist()
 MAX_RESOLUTION = 8192

--- a/front_end/primere_visuals.js
+++ b/front_end/primere_visuals.js
@@ -49,6 +49,14 @@ function createCardElement(checkpoint, container, SelectedModel, ModelType) {
     var imgsrc = prwPath + '/images/' + ModelType + '/' + previewName;
     var missingimgsrc = prwPath + '/images/missing.jpg';
 
+    let supportedImageExtensions = [ '.preview.jpg', '.jpeg', '.preview.jpeg', '.png', '.preview.png'];
+    let alternativeImgSources = []
+    for (let ending of supportedImageExtensions) {
+        var alternativeImgSrc = prwPath + '/images/' + ModelType + '/' + finalName + ending;
+        alternativeImgSources.push(alternativeImgSrc);
+    }
+    let currentAttempt = 0;
+
 	var card = document.createElement("div");
 	card.classList.add('visual-ckpt', 'version-' + versionString);
     if (SelectedModel === checkpoint) {
@@ -56,22 +64,35 @@ function createCardElement(checkpoint, container, SelectedModel, ModelType) {
     }
 
     const img = new Image();
-    img.src = imgsrc;
     img.onload = () => {
         const width = img.width;
         if (width > 0) {
-            card_html += '<img src="' + imgsrc + '" title="' + checkpoint_new + '" data-ckptname="' + checkpoint + '">';
+            card_html += '<img src="' + img.src + '" title="' + checkpoint_new + '" data-ckptname="' + checkpoint + '">';
             card.innerHTML = card_html;
             container.appendChild(card);
+            console.log('Image loaded successfully with image source: ' + img.src + ' ...')
         }
+        currentAttempt = 0;
     };
 
     img.onerror = () => {
-        card_html += '<img src="' + missingimgsrc + '" title="' + checkpoint_new + '" data-ckptname="' + checkpoint + '">';
-        card.innerHTML = card_html;
-        container.appendChild(card);
+        console.error('Image error detected with image source: ' + img.src + '. Attempting alternative image sources');
+        if (currentAttempt < alternativeImgSources.length) {
+            currentAttempt++;
+            img.src = alternativeImgSources[currentAttempt - 1];
+        } else {
+            card_html += '<img src="' + missingimgsrc + '" title="' + checkpoint_new + '" data-ckptname="' + checkpoint + '">';
+            card.innerHTML = card_html;
+            container.appendChild(card);
+            currentAttempt = 0;
+        }
+        // card_html += '<img src="' + missingimgsrc + '" title="' + checkpoint_new + '" data-ckptname="' + checkpoint + '">';
+        // card.innerHTML = card_html;
+        // container.appendChild(card);
     };
+    img.src = imgsrc;
 }
+
 
 app.registerExtension({
     name: "Primere.VisualMenu",


### PR DESCRIPTION
As the title says. 

You should be able to add any other file types to the list supportedImageExtensions as long as they can be read in using img.src = "...."

I tested all 5 of the new files types I added and they all work fine.

Stability Matrix and Auto1111 both have the .preview wording added to the end of their filetypes before the .png / .jpeg file endings, so this will make it a lot easier on users.