### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui_primere_nodes"
+description = "This extension provides various utility nodes. Inputs(prompt, styles, dynamic, merger, ...), Outputs(style pile), Dashboard(selectors, loader, switch, ...), Networks(LORA, Embedding, Hypernetwork), Visuals(visual selectors, )"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["Pillow", "PyYAML", "Requests", "addict", "aiohttp", "chardet", "clip", "dynamicprompts", "ftfy", "ipdb", "numpy", "opencv_contrib_python", "opencv_python", "opencv_python_headless", "pandas", "pefile", "piexif", "pipreqs", "pycocotools", "pyexiv2", "pytorch_lightning", "pytz", "regex", "segment_anything", "setuptools", "supervision", "timm", "tomli", "torch", "torchvision", "tqdm", "transformers", "ultralytics", "yapf", "openai-clip", "huggingface_hub"]
+
+[project.urls]
+Repository = "https://github.com/CosmicLaca/ComfyUI_Primere_Nodes"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI_Primere_Nodes"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!